### PR TITLE
Add Google Cloud support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree
 # /b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why
 # libc6-compat might be needed.
-RUN apk update && apk add --no-cache libc6-compat
+RUN apk add --no-cache libc6-compat
 
 # Set working directory in container
 WORKDIR /frontend
@@ -76,9 +76,11 @@ USER nextjs
 # set hostname to localhost
 ENV HOSTNAME "0.0.0.0"
 
+EXPOSE ${PORT}
+
 # Set labels
 LABEL vendor1="ABATE AI"
-LABEL com.abateai.release-date="2023-10-02"
-LABEL com.abateai.version="1.0.0"
+LABEL com.abateai.release-date="2023-10-04"
+LABEL com.abateai.version="1.0.1"
 
 CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
     container_name: backend
     build: ./api
     # Can also use --host 0.0.0.0
-    command: ["uvicorn app.index:app --host backend --port 8000 --reload"]
+    command: ["sh", "-c", "uvicorn app.index:app --host backend --port 8000 --reload"]
     restart: always
     volumes:
       - ./api/src:/usr/src/app

--- a/next.config.js
+++ b/next.config.js
@@ -20,7 +20,7 @@ const nextConfig = {
                 destination:
                     process.env.NODE_ENV === "development"
                         ? "http://backend:8000/api/:path*"
-                        : "/api/",
+                        : process.env.BACKEND_PRODUCTION_URL + "/api/",
             },
         ];
     },


### PR DESCRIPTION
Removed `apk update` and added `EXPOSE ${PORT}` for production environment to Dockerfile.

Adjusted api rewrite in next.config.js for backend production URL.

Fixed docker-compose.yml backend command to support api submodule v1.0.3+.

Finallly, updated api submodule to latest v1.0.4 which supports development and production environments.