### PR TITLE
Add :path parameter to next.config.js destination

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,7 @@ const nextConfig = {
     // - https://github.com/digitros/nextjs-fastapi/blob/main/next.config.js
     // - https://github.com/wpcodevo/nextjs-fastapi-framework/
     //   blob/main/next.config.js
+    // - https://nextjs.org/docs/app/api-reference/next-config-js/rewrites
     //
     // Somehow I figured out the magic is to use http://backend:8000/api/:path*
     // instead of http://127.0.0.1:8000/api/:path* for development. This allows
@@ -20,7 +21,7 @@ const nextConfig = {
                 destination:
                     process.env.NODE_ENV === "development"
                         ? "http://backend:8000/api/:path*"
-                        : "https://backend-rxmevdt6aq-uc.a.run.app/api/",
+                        : "https://backend-rxmevdt6aq-uc.a.run.app/api/:path*",
             },
         ];
     },


### PR DESCRIPTION
Added `:path*` to production destination of rewrites field in next.config.js to prevent automatically passing parameters in the query.